### PR TITLE
fix: find pwd url

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -143,7 +143,7 @@ export default function Login() {
             <text className='text-gray-500 text-sm dark:text-gray-400'>
               忘记账号密码？
               <a
-                href='https://www.haofenshu.com/findPwd/?roleType=2'
+                href='https://app.haofenshu.com/findPwd/?roleType=2'
                 target='_blank'
                 className='underline hover:text-gray-700'
                 rel='noreferrer'


### PR DESCRIPTION
原找回密码链接失效，会跳转到 yunxiao.com
更新链接为 https://app.haofenshu.com/findPwd/?roleType=2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Forgot password" link destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->