### PR TITLE
新增：考试详情显示年级排名

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -25,7 +25,19 @@ export async function fetchHFSApiFromServer<T>(
   },
 ): Promise<FetchHFSApiResponse<T>> {
   try {
-    const parsedUrl = fillTemplate(url, init.getParams)
+    let parsedUrl = fillTemplate(url, init.getParams)
+    // 处理查询参数
+    if (init.getParams && !url.includes('${')) {
+      // 如果 URL 中没有模板占位符，则将 getParams 作为查询参数
+      const searchParams = new URLSearchParams()
+      for (const [key, value] of Object.entries(init.getParams)) {
+        searchParams.append(key, String(value))
+      }
+      const queryString = searchParams.toString()
+      if (queryString) {
+        parsedUrl += (parsedUrl.includes('?') ? '&' : '?') + queryString
+      }
+    }
     const headers = {
       'Content-Type': 'application/json',
       'Hfs-token': init.token,

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -9,4 +9,5 @@ export const HFS_APIs = {
   paperRankInfo:
     'https://hfs-be.yunxiao.com/v3/exam/${examId}/papers/${paperId}/rank-info',
   lastExamOverview: 'https://hfs-be.yunxiao.com/v2/students/last-exam-overview',
+  examOverviewV4: 'https://hfs-be.yunxiao.com/v4/exam/overview',
 }

--- a/app/exam/[id]/page.tsx
+++ b/app/exam/[id]/page.tsx
@@ -18,7 +18,7 @@ import Navbar from '@/components/navBar'
 import { GithubSVGIcon } from '@/components/svg'
 import type { ExamObject, ExamRankInfo } from '@/types/exam'
 import { formatTimestamp } from '@/utils/time'
-import { useExamOverviewQuery, useUserSnapshotQuery } from '@/hooks/queries'
+import { useExamOverviewQuery, useExamOverviewV4Query, useUserSnapshotQuery } from '@/hooks/queries'
 import { useStorage } from '@/hooks/useStorage'
 
 function RankInfoComponent({
@@ -83,6 +83,10 @@ export default function ExamPage(props: { params: Promise<{ id: string }> }) {
     isError: isExamOverviewError,
     isPending: isExamOverviewPending,
   } = useExamOverviewQuery(token, params.id)
+  const { data: examOverviewV4 } = useExamOverviewV4Query(
+    token,
+    examOverview?.examId,
+  )
 
   const changeDisplayedMode = useCallback((paperId: string) => {
     setDisplayedPapersMode((prevState) => {
@@ -265,6 +269,18 @@ export default function ExamPage(props: { params: Promise<{ id: string }> }) {
                       ? `${examObject.detail.classRank} (打败了全班${examObject.detail.classDefeatRatio}%的人)`
                       : examObject.detail.classRankS
                     : '...'}
+                </div>
+              </div>
+              <div>
+                <div className='text-gray-500 text-sm dark:text-gray-400'>
+                  年级排名
+                </div>
+                <div className='font-medium'>
+                  {examOverviewV4?.compare?.curGradeRank
+                    ? examOverviewV4.compare.curGradeRank
+                    : examObject?.detail?.gradeRank
+                      ? examObject.detail.gradeRank
+                      : '获取失败 无此数据'}
                 </div>
               </div>
             </div>

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -4,6 +4,7 @@ import { HFS_APIs } from '@/app/constants'
 import type {
   ExamDetail,
   ExamListResponse,
+  ExamOverviewV4,
   LastExamOverview,
   UserSnapshot,
 } from '@/types/exam'
@@ -16,6 +17,11 @@ export const queryKeys = {
   examOverview: (examId: number) => [
     ...queryKeys.all(),
     'examOverview',
+    examId,
+  ],
+  examOverviewV4: (examId: number) => [
+    ...queryKeys.all(),
+    'examOverviewV4',
     examId,
   ],
   examRankInfo: (examId: number) => [
@@ -172,5 +178,33 @@ export const useLastExamOverviewQuery = (token: string | undefined) => {
           return response.payload
         }
       : skipToken,
+  })
+}
+
+export const useExamOverviewV4Query = (
+  token: string | undefined,
+  examId?: number,
+) => {
+  return useQuery({
+    queryKey: examId !== undefined ? queryKeys.examOverviewV4(examId) : ['examOverviewV4', 'undefined'],
+    queryFn:
+      token && examId !== undefined
+        ? async () => {
+            const response = await fetchHFSApiFromServer<ExamOverviewV4>(
+              HFS_APIs.examOverviewV4,
+              {
+                method: 'GET',
+                token: token,
+                getParams: {
+                  examId: String(examId),
+                },
+              },
+            )
+            if (!response.ok) {
+              throw new Error(response.errMsg || '获取年级排名失败')
+            }
+            return response.payload
+          }
+        : skipToken,
   })
 }

--- a/types/exam.ts
+++ b/types/exam.ts
@@ -136,3 +136,10 @@ export type LastExamOverview =
       rankRaise: number
     }
   | Record<string, never>
+
+// v4 接口返回的考试概览数据
+export interface ExamOverviewV4 {
+  compare: {
+    curGradeRank: number
+  }
+}


### PR DESCRIPTION
## 新增功能

在考试详情页面添加"年级排名"显示

## 主要修改

- 新增 v4 接口调用 (`/v4/exam/overview?examId={id}`)
- 添加 `ExamOverviewV4` 类型定义和 `useExamOverviewV4Query` hook
- 增强 `fetchHFSApiFromServer` 支持查询参数传递
- 页面显示优先使用 v4 接口的 `compare.curGradeRank`，失败时回退到 v3 的 `gradeRank`（但是这个v3的没啥用，就是-1）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grade ranking information to exam pages, displaying students' current position within their grade level for better context on exam performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->