### PR TITLE
feat:获取所有考试（而非 120天）

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,7 +1,7 @@
 export const HFS_APIs = {
   login: 'https://hfs-be.yunxiao.com/v2/users/sessions',
   userSnapshot: 'https://hfs-be.yunxiao.com/v2/user-center/user-snapshot',
-  examList: 'https://hfs-be.yunxiao.com/v3/exam/list?start=0&limit=100',
+  examList: 'https://hfs-be.yunxiao.com/v2/wrong-items/overview',
   examOverview: 'https://hfs-be.yunxiao.com/v3/exam/${examId}/overview',
   examRankInfo: 'https://hfs-be.yunxiao.com/v3/exam/${examId}/rank-info',
   answerPicture:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ function ExamCard({
 export default function ExamSelector() {
   const router = useRouter()
   const [token, setToken] = useStorage('hfs_token')
-  const { data: examList, isError } = useExamListQuery(token)
+  const { data: examList, isError, isLoading } = useExamListQuery(token)
 
   if (!token) {
     toast.error('你还没登录，返回登录页')
@@ -77,20 +77,27 @@ export default function ExamSelector() {
           </div>
         </div>
       </div>
-      <div className=' grid gap-6 pt-6 md:grid-cols-2 md:pt-6 lg:grid-cols-3 xl:grid-cols-4'>
-        {examList?.map((exam) => {
-          return (
-            <ExamCard
-              key={exam.examId}
-              name={exam.name}
-              score={exam.score}
-              released={exam.released}
-              examId={exam.examId}
-              router={router}
-            />
-          )
-        })}
-      </div>
+      {isLoading ? (
+        <div className='flex flex-col items-center justify-center py-20'>
+          <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-sky-500' />
+          <p className='mt-4 text-gray-500'>正在加载考试列表...</p>
+        </div>
+      ) : (
+        <div className='grid gap-6 pt-6 md:grid-cols-2 md:pt-6 lg:grid-cols-3 xl:grid-cols-4'>
+          {examList?.map((exam) => {
+            return (
+              <ExamCard
+                key={exam.examId}
+                name={exam.name}
+                score={exam.score}
+                released={exam.released}
+                examId={exam.examId}
+                router={router}
+              />
+            )
+          })}
+        </div>
+      )}
       <div className='grow' />
       <div className='divide-y pt-10'>
         <div />

--- a/types/exam.ts
+++ b/types/exam.ts
@@ -113,6 +113,25 @@ export type ExamListResponse = {
   }[]
 }
 
+// v2/wrong-items/overview 接口返回的数据结构
+export interface WrongItemsOverviewResponse {
+  subject: string
+  noReview: number
+  semesterList: {
+    name: string
+    wrongNum: number
+    reviewNum: number
+  }[]
+  examList: {
+    examName: string
+    examType: number
+    examTime: number
+    examId: string
+    wrongNum: number
+    reviewNum: number
+  }[]
+}
+
 export type LastExamOverview =
   | {
       examId: number


### PR DESCRIPTION
现在可以获取所有的考试了
第一次加载考试列表可能会有些慢（之后会缓存 1 个小时）
主要思路：通过获取错题的接口可以获取到所有的考试id
思路提供：@CYQawa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading indicator that displays while fetching exam data, providing better feedback during data retrieval.

* **Improvements**
  * Optimized exam data retrieval with improved caching strategy for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->